### PR TITLE
Unrolling brocast

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ Example of a validation image from a UIUC model run on AR_StJoe_Mbs_poly
     Flag to enable the saving of debugging feedback images.
 
 ## Authors and acknowledgment
-This repo was created by and is maintained by the UIUC team.
+This repo was created by and is maintained by the amazing UIUC team.

--- a/src/grading.py
+++ b/src/grading.py
@@ -26,10 +26,17 @@ def grade_poly_raster(pred_image, true_image, feedback_image=None):
         return (0, 0, 0, 0, feedback_image)
 
     if feedback_image is not None:
-        feedback_image[(true_image>=1).all(-1)] = MISS_COLOR
-        feedback_image[(pred_image>=1).all(-1)] = FAIL_COLOR
-        feedback_image[(intersection==1).all(-1)] = CORRECT_COLOR
+        feedback_image[0][(true_image>=1)[0]] = MISS_COLOR[0]
+        feedback_image[1][(true_image>=1)[0]] = MISS_COLOR[1]
+        feedback_image[2][(true_image>=1)[0]] = MISS_COLOR[2]
+        feedback_image[0][(pred_image>=1)[0]] = FAIL_COLOR[0]
+        feedback_image[1][(pred_image>=1)[0]] = FAIL_COLOR[1]
+        feedback_image[2][(pred_image>=1)[0]] = FAIL_COLOR[2]
+        feedback_image[0][(intersection==1)[0]] = CORRECT_COLOR[0]
+        feedback_image[1][(intersection==1)[0]] = CORRECT_COLOR[1]
+        feedback_image[2][(intersection==1)[0]] = CORRECT_COLOR[2]
 
+        #raise Exception(f"feedback Dim {type((true_image>=1))}\n{(true_image>=1).shape}\n {type(feedback_image)} \n{feedback_image[0].shape}")
     recall = true_positive / np.count_nonzero(true_image)
     precision = true_positive / np.count_nonzero(pred_image)
     


### PR DESCRIPTION
See log `/projects/bbym/shared/commonDebug/uiuc-pipeline/logs/log.log` for details.

We're getting this traceback,
```
30/04/2024 13:59:06 ERROR - Process 928215 - Error in step Validating Output on 0 : boolean index did not match indexed array along dimension 0; dimension is 3 but corresponding boolean dimension is 1
Traceback (most recent call last):
  File "/projects/bbym/shared/commonDebug/uiuc-pipeline/src/pipeline_manager.py", line 292, in _start_worker
    result = step.func(arg_data.id, *func_args)
  File "/projects/bbym/shared/commonDebug/uiuc-pipeline/src/pipeline_steps.py", line 301, in validation
    feature_score = grade_poly_raster(feature_mask, true_mask, feedback_image=feedback_image)
  File "/projects/bbym/shared/commonDebug/uiuc-pipeline/submodules/validation/src/grading.py", line 29, in grade_poly_raster
    feedback_image[(true_image>=1).all(-1)] = MISS_COLOR
IndexError: boolean index did not match indexed array along dimension 0; dimension is 3 but corresponding boolean dimension is 1

30/04/2024 13:59:39 DEBUG - P-928207 - KY_WestFranklin - Prediction contained 9679 total segmentations
30/04/2024 13:59:45 ERROR - Process 928216 - Error in step Validating Output on 1 : boolean index did not match indexed array along dimension 0; dimension is 3 but corresponding boolean dimension is 1
Traceback (most recent call last):
  File "/projects/bbym/shared/commonDebug/uiuc-pipeline/src/pipeline_manager.py", line 292, in _start_worker
    result = step.func(arg_data.id, *func_args)
  File "/projects/bbym/shared/commonDebug/uiuc-pipeline/src/pipeline_steps.py", line 301, in validation
    feature_score = grade_poly_raster(feature_mask, true_mask, feedback_image=feedback_image)
  File "/projects/bbym/shared/commonDebug/uiuc-pipeline/submodules/validation/src/grading.py", line 29, in grade_poly_raster
    feedback_image[(true_image>=1).all(-1)] = MISS_COLOR
IndexError: boolean index did not match indexed array along dimension 0; dimension is 3 but corresponding boolean dimension is 1
```
when running
```
python pipeline.py -v --data /projects/bbym/saxton/MockValData/validation --output ./output --legends /projects/bbym/saxton/MockValData/validation --feedback ./feedback --log ./logs/log.log --model golden_muscat --validation /projects/bbym/saxton/MockValData/validation_labels --output_types cdr_json geopackage raster_masks
```
using an environment built like
```
module load anaconda3_gpu
conda create --name CMAAS_test python=3.10
conda activate CMAAS_test
python -m venv venv
sed -i 's#^\(-e .*\)$#\#\1#' requirements.txt && pip install --no-cache -r requirements.txt
pip install --no-cache -r requirements.txt
```